### PR TITLE
GeonKick update and cleanup

### DIFF
--- a/geonkick/geonkick.spec
+++ b/geonkick/geonkick.spec
@@ -11,7 +11,7 @@ Release: 1%{?dist}
 Summary: Drum Software Synthesizer
 URL:     https://gitlab.com/iurie-sw/geonkick
 Group:   Applications/Multimedia
-License: GPLv2+
+License: GPLv3
 
 Source0: https://gitlab.com/iurie-sw/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
 

--- a/geonkick/geonkick.spec
+++ b/geonkick/geonkick.spec
@@ -6,14 +6,14 @@
 %global shortcommit0 %(c=%{commit0}; echo ${c:0:7})
 
 Name:    geonkick
-Version: 2.0.0
+Version: 2.1.0
 Release: 1%{?dist}
 Summary: Drum Software Synthesizer
-URL:     https://gitlab.com/geontime/geonkick
+URL:     https://gitlab.com/iurie-sw/geonkick
 Group:   Applications/Multimedia
 License: GPLv2+
 
-Source0: https://gitlab.com/geontime/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
+Source0: https://gitlab.com/iurie-sw/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
 
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
@@ -23,7 +23,7 @@ BuildRequires: jack-audio-connection-kit-devel
 BuildRequires: lv2-devel
 BuildRequires: libsndfile-devel
 BuildRequires: rapidjson-devel
-BuildRequires: cmake
+BuildRequires: cmake make
 BuildRequires: desktop-file-utils
 BuildRequires: redkite
 BuildRequires: libX11-devel
@@ -71,12 +71,15 @@ fi
 /usr/bin/update-mime-database %{?fedora:-n} %{_datadir}/mime &> /dev/null || :
 
 %files
-%doc LICENSE README.md
+%doc LICENSE README.md doc/Documentation.md
 %{_bindir}/*
 %{_libdir}/*
 %{_datadir}/*
 
 %changelog
+* Sat May 09 2020 Bruno Vernay <brunovern.a@gmail.com> - 2.1.0-1
+- Update to 2.1.0, update the URL, add make dependency, add doc
+
 * Fri Apr 17 2020 Yann Collette <ycollette.nospam@free.fr> - 2.0.0-1
 - update to 2.0.0
 

--- a/geonkick/redkite.spec
+++ b/geonkick/redkite.spec
@@ -52,10 +52,10 @@ make DESTDIR=%{buildroot} install
 * Fri Apr 17 2020 Yann Collette <ycollette.nospam@free.fr> - 0.8.1-1
 - update to 0.8.1-1
 
-* Sat Dec 29 2019 Yann Collette <ycollette.nospam@free.fr> - 0.8.0-1
+* Sun Apr 5 2020 Yann Collette <ycollette.nospam@free.fr> - 0.8.0-1
 - update to 0.8.0
 
-* Sat Dec 29 2019 Yann Collette <ycollette.nospam@free.fr> - 0.6.3-1
+* Sat Dec 28 2019 Yann Collette <ycollette.nospam@free.fr> - 0.6.3-1
 - update to 0.6.3
 
 * Wed Oct 16 2019 Yann Collette <ycollette.nospam@free.fr> - 0.6.2-1

--- a/geonkick/redkite.spec
+++ b/geonkick/redkite.spec
@@ -5,19 +5,19 @@
 
 Name:    redkite
 Version: 0.8.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: A cross-platform GUI toolkit in C++.
-URL:     https://gitlab.com/geontime/redkite
+URL:     https://gitlab.com/iurie-sw/redkite
 Group:   Applications/Multimedia
-License: GPLv2+
+License: GPLv3
 
-Source0: https://gitlab.com/geontime/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
+Source0: https://gitlab.com/iurie-sw/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
 
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires: gcc gcc-c++
 BuildRequires: cairo-devel
-BuildRequires: cmake
+BuildRequires: cmake make
 
 %description
 Redkite is a small free software and cross-platform GUI toolkit. It is developed in C++11&14 and inspired from other well known GUI toolkits.
@@ -46,6 +46,9 @@ make DESTDIR=%{buildroot} install
 %{_includedir}/*
 
 %changelog
+* Sat May 09 2020 Bruno Vernay <brunovern.a@gmail.com> - 0.8.1-2
+- Update the URL, add make dependency, change licence to GPLv3
+
 * Fri Apr 17 2020 Yann Collette <ycollette.nospam@free.fr> - 0.8.1-1
 - update to 0.8.1-1
 


### PR DESCRIPTION
GeonKick: Updated  to 2.1.0 and add a doc in documentation
RedKite and GeonKick :
- Update the URL ("Group 'geontime' was moved to 'iurie-sw'. Please update any links and bookmarks that may still have the old path.")
- Add make dependency (I have errors without it)
- Licence GPLv3
