### PR TITLE
Fix purr-data dependency

### DIFF
--- a/purr-data/purr-data.spec
+++ b/purr-data/purr-data.spec
@@ -98,7 +98,7 @@ Requires: ladspa-swh-plugins
 Requires: ladspa-mcp-plugins
 Requires: ladspa-cmt-plugins
 Requires: ladspa-blop-plugins
-Requires: ladspa-VCO-plugins
+Requires: ladspa-vco-plugins
 Requires: ladspa-fil-plugins
 Requires: mda-lv2
 Requires: dssi


### PR DESCRIPTION
There is a dependency error when trying to install purr-data.

```
$ sudo dnf install purr-data
Error: 
 Problem: conflicting requests
  - nothing provides ladspa-VCO-plugins needed by purr-data-2.12.0-1.fc32.x86_64
  - nothing provides ladspa-VCO-plugins needed by purr-data-2.13.0-1.fc32.x86_64
```

Package name in fedora Repos seems to be ladspa-vco-plugins.
```
dnf search ladspa-vc
ladspa-vco-plugins.x86_64 : Anti-aliased pulse and sawtooth oscillators
```